### PR TITLE
ci: migrate workflows to Blacksmith runners

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     outputs:
       desktop: ${{ steps.filter.outputs.desktop }}
       renderer: ${{ steps.filter.outputs.renderer }}
@@ -94,7 +94,7 @@ jobs:
   version:
     needs: changes
     if: ${{ needs.changes.outputs.desktop == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     environment: BUILD_PRODUCTION
     outputs:
       build_version: ${{ steps.version.outputs.build_version }}
@@ -106,6 +106,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          check-latest: true
           cache: yarn
           cache-dependency-path: '**/yarn.lock'
 
@@ -146,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-26]
+        os: [blacksmith-4vcpu-ubuntu-2204, blacksmith-4vcpu-windows-2025, macos-26]
 
     steps:
       - uses: actions/checkout@v6
@@ -156,6 +157,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          check-latest: true
           cache: yarn
           cache-dependency-path: '**/yarn.lock'
 
@@ -245,7 +247,7 @@ jobs:
     name: Publish Remote Renderer
     needs: changes
     if: ${{ needs.changes.outputs.renderer == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     environment: BUILD_PRODUCTION
     concurrency:
       group: remote-renderer-publish
@@ -259,6 +261,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          check-latest: true
           cache: yarn
           cache-dependency-path: '**/yarn.lock'
 
@@ -324,7 +327,7 @@ jobs:
     name: Create GitHub Prerelease
     needs: [changes, version, build]
     if: ${{ needs.changes.outputs.desktop == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
 
     steps:
       - uses: actions/checkout@v6
@@ -361,7 +364,7 @@ jobs:
   skip-build:
     needs: changes
     if: ${{ needs.changes.outputs.desktop != 'true' && needs.changes.outputs.renderer != 'true' && needs.changes.outputs.retention != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Skip dev build
         run: echo "Skipping dev workflow because no desktop, renderer, or retention files changed."

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -147,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [blacksmith-4vcpu-ubuntu-2204, blacksmith-4vcpu-windows-2025, macos-26]
+        os: [blacksmith-4vcpu-ubuntu-2204, blacksmith-4vcpu-windows-2025, blacksmith-6vcpu-macos-26]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -15,7 +15,7 @@ on:
           - all
           - blacksmith-4vcpu-ubuntu-2204
           - blacksmith-4vcpu-windows-2025
-          - macos-26
+          - blacksmith-6vcpu-macos-26
           - windows+macos
         default: all
       upload_to_s3:
@@ -86,7 +86,7 @@ jobs:
     environment: BUILD_PRODUCTION
     strategy:
       matrix:
-        os: ${{ fromJson(inputs.build_os == 'all' && '["blacksmith-4vcpu-ubuntu-2204","blacksmith-4vcpu-windows-2025","macos-26"]' || (inputs.build_os == 'windows+macos' && '["blacksmith-4vcpu-windows-2025","macos-26"]' || format('["{0}"]', inputs.build_os))) }}
+        os: ${{ fromJson(inputs.build_os == 'all' && '["blacksmith-4vcpu-ubuntu-2204","blacksmith-4vcpu-windows-2025","blacksmith-6vcpu-macos-26"]' || (inputs.build_os == 'windows+macos' && '["blacksmith-4vcpu-windows-2025","blacksmith-6vcpu-macos-26"]' || format('["{0}"]', inputs.build_os))) }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -13,8 +13,8 @@ on:
         type: choice
         options:
           - all
-          - ubuntu-latest
-          - windows-latest
+          - blacksmith-4vcpu-ubuntu-2204
+          - blacksmith-4vcpu-windows-2025
           - macos-26
           - windows+macos
         default: all
@@ -86,7 +86,7 @@ jobs:
     environment: BUILD_PRODUCTION
     strategy:
       matrix:
-        os: ${{ fromJson(inputs.build_os == 'all' && '["ubuntu-latest","windows-latest","macos-26"]' || (inputs.build_os == 'windows+macos' && '["windows-latest","macos-26"]' || format('["{0}"]', inputs.build_os))) }}
+        os: ${{ fromJson(inputs.build_os == 'all' && '["blacksmith-4vcpu-ubuntu-2204","blacksmith-4vcpu-windows-2025","macos-26"]' || (inputs.build_os == 'windows+macos' && '["blacksmith-4vcpu-windows-2025","macos-26"]' || format('["{0}"]', inputs.build_os))) }}
 
     steps:
       - uses: actions/checkout@v6
@@ -96,6 +96,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          check-latest: true
           cache: yarn
           cache-dependency-path: '**/yarn.lock'
 
@@ -159,7 +160,7 @@ jobs:
           fi
 
       - name: Publish changelog (optional, single-run on ubuntu)
-        if: ${{ inputs.publish_changelog == true && matrix.os == 'ubuntu-latest' }}
+        if: ${{ inputs.publish_changelog == true && matrix.os == 'blacksmith-4vcpu-ubuntu-2204' }}
         shell: bash
         run: |
           VERSION_ARGS=()
@@ -201,7 +202,7 @@ jobs:
     name: Publish Remote Renderer
     needs: build
     if: ${{ inputs.publish_renderer == true }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     environment: BUILD_PRODUCTION
     concurrency:
       group: remote-renderer-publish
@@ -215,6 +216,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          check-latest: true
           cache: yarn
           cache-dependency-path: '**/yarn.lock'
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -19,7 +19,7 @@ jobs:
     environment: BUILD_PRODUCTION
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-26]
+        os: [blacksmith-4vcpu-ubuntu-2204, blacksmith-4vcpu-windows-2025, macos-26]
 
     steps:
       - uses: actions/checkout@v6
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          check-latest: true
           cache: yarn
           cache-dependency-path: '**/yarn.lock'
 
@@ -79,7 +80,7 @@ jobs:
 
   renderer:
     name: Build Remote Renderer
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
 
     steps:
       - uses: actions/checkout@v6
@@ -87,6 +88,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          check-latest: true
           cache: yarn
           cache-dependency-path: '**/yarn.lock'
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -19,7 +19,7 @@ jobs:
     environment: BUILD_PRODUCTION
     strategy:
       matrix:
-        os: [blacksmith-4vcpu-ubuntu-2204, blacksmith-4vcpu-windows-2025, macos-26]
+        os: [blacksmith-4vcpu-ubuntu-2204, blacksmith-4vcpu-windows-2025, blacksmith-6vcpu-macos-26]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,7 +19,7 @@ jobs:
     environment: BUILD_PRODUCTION
     strategy:
       matrix:
-        os: [blacksmith-4vcpu-ubuntu-2204, blacksmith-4vcpu-windows-2025, macos-26]
+        os: [blacksmith-4vcpu-ubuntu-2204, blacksmith-4vcpu-windows-2025, blacksmith-6vcpu-macos-26]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,7 +19,7 @@ jobs:
     environment: BUILD_PRODUCTION
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-26]
+        os: [blacksmith-4vcpu-ubuntu-2204, blacksmith-4vcpu-windows-2025, macos-26]
 
     steps:
       - uses: actions/checkout@v6
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          check-latest: true
           cache: yarn
           cache-dependency-path: '**/yarn.lock'
 
@@ -97,7 +98,7 @@ jobs:
           if-no-files-found: error
 
       - name: Publish changelog (single-run on ubuntu)
-        if: ${{ matrix.os == 'ubuntu-latest' && !contains(github.ref_name, 'dev') }}
+        if: ${{ matrix.os == 'blacksmith-4vcpu-ubuntu-2204' && !contains(github.ref_name, 'dev') }}
         shell: bash
         run: |
           VERSION_ARGS=()
@@ -112,7 +113,7 @@ jobs:
     name: Create GitHub Release
     needs: build
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/desktop-s3-cleanup.yml
+++ b/.github/workflows/desktop-s3-cleanup.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          check-latest: true
           cache: yarn
           cache-dependency-path: "**/yarn.lock"
 

--- a/.github/workflows/desktop-s3-cleanup.yml
+++ b/.github/workflows/desktop-s3-cleanup.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     environment: BUILD_PRODUCTION
 
     steps:

--- a/.github/workflows/desktop-tests.yml
+++ b/.github/workflows/desktop-tests.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          check-latest: true
           cache: yarn
           cache-dependency-path: '**/yarn.lock'
 

--- a/.github/workflows/desktop-tests.yml
+++ b/.github/workflows/desktop-tests.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   common:
     name: Common checks
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/desktop-tests.yml
+++ b/.github/workflows/desktop-tests.yml
@@ -65,8 +65,8 @@ jobs:
 
   macos-updater:
     name: macOS updater checks
-    if: ${{ inputs.build_os == 'all' || inputs.build_os == 'macos-26' || inputs.build_os == 'windows+macos' }}
-    runs-on: macos-26
+    if: ${{ inputs.build_os == 'all' || inputs.build_os == 'blacksmith-6vcpu-macos-26' || inputs.build_os == 'windows+macos' }}
+    runs-on: blacksmith-6vcpu-macos-26
 
     steps:
       - uses: actions/checkout@v6
@@ -76,6 +76,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          check-latest: true
           cache: yarn
           cache-dependency-path: '**/yarn.lock'
 

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     environment: BUILD_PRODUCTION
 
     steps:

--- a/.github/workflows/publish-component.yml
+++ b/.github/workflows/publish-component.yml
@@ -32,8 +32,8 @@ on:
         type: choice
         options:
           - all
-          - windows-latest
-          - ubuntu-latest
+          - blacksmith-4vcpu-windows-2025
+          - blacksmith-4vcpu-ubuntu-2204
           - macos-26
         default: all
 
@@ -48,7 +48,7 @@ concurrency:
 jobs:
   prepare:
     name: Prepare component release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     outputs:
       matrix: ${{ steps.release.outputs.matrix }}
       prerelease: ${{ steps.release.outputs.prerelease }}
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ inputs.build_os }}" == "all" ]]; then
-            matrix='["ubuntu-latest","windows-latest","macos-26"]'
+            matrix='["blacksmith-4vcpu-ubuntu-2204","blacksmith-4vcpu-windows-2025","macos-26"]'
           else
             matrix='["${{ inputs.build_os }}"]'
           fi
@@ -93,6 +93,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
+          check-latest: true
           cache: yarn
           cache-dependency-path: "**/yarn.lock"
 
@@ -166,7 +167,7 @@ jobs:
   release:
     name: Create component release
     needs: [prepare, build]
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Download prepared assets
         uses: actions/download-artifact@v8

--- a/.github/workflows/publish-component.yml
+++ b/.github/workflows/publish-component.yml
@@ -34,7 +34,7 @@ on:
           - all
           - blacksmith-4vcpu-windows-2025
           - blacksmith-4vcpu-ubuntu-2204
-          - macos-26
+          - blacksmith-6vcpu-macos-26
         default: all
 
 permissions:
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ inputs.build_os }}" == "all" ]]; then
-            matrix='["blacksmith-4vcpu-ubuntu-2204","blacksmith-4vcpu-windows-2025","macos-26"]'
+            matrix='["blacksmith-4vcpu-ubuntu-2204","blacksmith-4vcpu-windows-2025","blacksmith-6vcpu-macos-26"]'
           else
             matrix='["${{ inputs.build_os }}"]'
           fi


### PR DESCRIPTION
Redo of #124 against `dev`. That PR branched off `main`, and `dev` is 20+ commits ahead with a substantially different `.github/workflows/` tree (it has `desktop-tests.yml`, `desktop-s3-cleanup.yml`, `publish-component.yml`, and a reworked `build-dev.yml` that `main` does not), so retargeting the base would have dragged 4 unrelated `main` commits into the diff and applied the migration to stale files. This branch applies the same migration directly to `dev`'s workflows.

Every job moves to Blacksmith: Linux to `blacksmith-4vcpu-ubuntu-2204`, Windows to `blacksmith-4vcpu-windows-2025`, and macOS to `blacksmith-6vcpu-macos-26` (Apple Silicon M4, same macOS 26 image as the GitHub-hosted `macos-26`, 6 vCPU is the smallest macOS tier offered).

```yaml
    strategy:
      matrix:
        os: [blacksmith-4vcpu-ubuntu-2204, blacksmith-4vcpu-windows-2025, blacksmith-6vcpu-macos-26]
```

Those labels double as `build_os` dispatch values and as job guards, so the `workflow_dispatch` choice options in `build-manual.yml` / `publish-component.yml`, the JSON matrix strings, the `matrix.os == 'ubuntu-latest'` conditions on the single-run "publish changelog" steps, and the `inputs.build_os == 'macos-26'` guard on the `macos-updater` job were all updated in lockstep, so those conditional jobs and steps still fire exactly as before.

Also carried over the fix from #124: `check-latest: true` on `actions/setup-node`. Blacksmith's toolcaches ship an older Node 22 patch (22.19.0 on Windows 2025, 22.22.0 on Ubuntu 22.04) than the `^22.22.2` that the pinned `node-gyp@13.0.0` requires, which aborts `yarn install --frozen-lockfile`; `check-latest` makes the action resolve the newest 22.x instead of the cached patch.

```yaml
      - uses: actions/setup-node@v6
        with:
          node-version: 22
          check-latest: true
```

One behavior note: the Linux builds now run on Ubuntu 22.04 rather than `ubuntu-latest` (24.04). For the packaged Linux artifacts that means an older glibc, which generally widens compatibility, but it is a real change to the build environment. Say the word if you would rather have `blacksmith-4vcpu-ubuntu-2404`.
